### PR TITLE
Don't use time.RFC3339Nano format in envelope

### DIFF
--- a/appinsights/telemetrycontext.go
+++ b/appinsights/telemetrycontext.go
@@ -2,7 +2,6 @@ package appinsights
 
 import (
 	"strings"
-	"time"
 
 	"github.com/Microsoft/ApplicationInsights-Go/appinsights/contracts"
 )
@@ -69,7 +68,7 @@ func (context *TelemetryContext) envelop(item Telemetry) *contracts.Envelope {
 		timestamp = currentClock.Now()
 	}
 
-	envelope.Time = timestamp.UTC().Format(time.RFC3339Nano)
+	envelope.Time = timestamp.UTC().Format("2006-01-02T15:04:05.999999Z")
 
 	if contextTags := item.ContextTags(); contextTags != nil {
 		envelope.Tags = contextTags


### PR DESCRIPTION
The AppInsights backend fails to parse timestamp microseconds correctly if the Golang time.RFC3339Nano format is used in the envelope.  When this happens, the backend truncates to millisecond resolution, meaning that events can appear out of order if not distinguishable by millisecond.  Things work correctly if format string "2006-01-02T15:04:05.999999Z" is used.

Also note https://github.com/Microsoft/ApplicationInsights-Home/issues/189.